### PR TITLE
Fix scolling issue and duplicate heading issue

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -6,18 +6,13 @@
 /* Fix for over-scrolling and black bar at top */
 html {
   overflow-x: hidden;
-  overscroll-behavior: none;
-  overscroll-behavior-y: none;
-  height: 100%;
 }
 
 body {
   overflow-x: hidden;
-  overscroll-behavior: none;
-  overscroll-behavior-y: none;
   -webkit-overflow-scrolling: touch;
   background-color: #fdfdfd;
-  min-height: 100%;
+  min-height: 100vh;
 }
 
 /* Full-width layout - remove max-width constraint */

--- a/team/directors.md
+++ b/team/directors.md
@@ -1,8 +1,8 @@
 ---
 layout: page
+title: Board of Directors
 permalink: /team/directors/
 ---
-# Board of Directors
 
 The Board of Directors are legally responsible for all aspects of the company.
 

--- a/team/fellows.md
+++ b/team/fellows.md
@@ -1,9 +1,8 @@
 ---
 layout: page
+title: Our fellows
 permalink: /team/fellows/
 ---
-
-# Our fellows
 
 Code makes the world go around and our engineers are the ones who do the magic. Note that LSF offers short term fellowships for engineers and as such everyone has the same job title of Software Engineering Fellow.
 

--- a/team/leadership.md
+++ b/team/leadership.md
@@ -1,9 +1,8 @@
 ---
 layout: page
+title: Leadership Team
 permalink: /team/leadership/
 ---
-
-# Leadership Team
 
 The LSF leadership team are the people who manage day to day operations of LSF. 
 

--- a/team/volunteers.md
+++ b/team/volunteers.md
@@ -1,9 +1,8 @@
 ---
 layout: page
+title: Our volunteers
 permalink: /team/volunteers/
 ---
-
-# Our volunteers
 
 Volunteers are key to making it possible for us to build large scale software with small teams. Thank you to those who make it possible to do this!
 


### PR DESCRIPTION
This PR is to resolve the scrolling issue on the website and duplicating heading issue.

### Changes
- Removed height: 100% from html - This was restricting the page height and preventing proper scrolling
- Removed overscroll-behavior: none from both html and body - These properties were blocking the natural scroll behavior
- Changed min-height: 100% to min-height: 100vh on body - This ensures the body is at least viewport height, but can expand
- Each team page had a markdown heading (e.g., # Our fellows) in the content, and the Jekyll page layout was also automatically displaying the page title. This caused the heading to appear twice when deployed and fixed it.